### PR TITLE
Update ExportCatalogHelper.php

### DIFF
--- a/classes/helper/ExportCatalogHelper.php
+++ b/classes/helper/ExportCatalogHelper.php
@@ -299,7 +299,9 @@ class ExportCatalogHelper
 
         /** @var OfferItem|ProductItem $obItem */
         if (!empty($obItem->preview_image_yandex)) {
-            $arResult[] = $obItem->preview_image_yandex->path;
+            $arResult[] = $obItem->preview_image_yandex->path;   
+        } elseif (!empty($obItem->preview_image)) {
+            $arResult[] = $obItem->preview_image->path;
         }
 
         $bFieldImages = YandexMarketSettings::getValue('field_images', false);
@@ -307,9 +309,15 @@ class ExportCatalogHelper
         if (!$bFieldImages) {
             return $arResult;
         }
-
-        foreach ($obItem->images_yandex as $obImage) {
-            $arResult[] = $obImage->path;
+           
+        if (!empty($obItem->images_yandex)) {
+            foreach ($obItem->images_yandex as $obImage) {
+                $arResult[] = $obImage->path;
+            }
+        } else {
+            foreach ($obItem->images as $obImage) {
+                $arResult[] = $obImage->path;
+            }
         }
 
         return $arResult;


### PR DESCRIPTION
There was exceptions from foreach loop if there is no images was added to images_yandex collection.
Small validation for existing images fixing that problem. After that, yandex validation will show user about non existing images on specific offers, that's much convinient than exception in somewhere of the list.

Also if there is no images in specific yandex images fields, that will be more intuitive if we load main images.