### PR TITLE
Changing preview_text to description

### DIFF
--- a/classes/helper/ExportCatalogHelper.php
+++ b/classes/helper/ExportCatalogHelper.php
@@ -222,7 +222,7 @@ class ExportCatalogHelper
             'images'         => $this->getOfferImages($obOffer, $obProduct),
             'properties'     => $this->getOfferProperties($obOffer),
             'auto_discounts' => YandexMarketSettings::getValue('field_enable_auto_discounts', false),
-            'description'    => $obOffer->preview_text,
+            'description'    => $obOffer->description ? $obOffer->description : $obProduct->description,
             'brand_name'     => $this->getBrandName($obProduct),
             'old_price'      => $this->getOfferOldPrice($obOffer),
         ];


### PR DESCRIPTION
Preview text is not siutable for description field, because Yandex is waitng for full article about product, not a preview text.
Also checking existing of description in offer, and changing to product description if there is none.

Yandex accepts html markup in description field of their yml files